### PR TITLE
Finalise gitops notebook creation walkthrough

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,12 +9,12 @@ This process assumes you already have an OpenShift 4.12+ running with cluster ad
 You will also need the OpenShift client ~oc~.
 
 
-** Step 1 - Install OpenShift GitOps
+** Step 1 - Install openshift gitops
 
 The goal of this setup process is to be as declarative as possible. With this in mind our first step on the new cluster will be to install the [[https://www.redhat.com/en/technologies/cloud-computing/openshift/gitops][OpenShift GitOps]] operator and create an instance of [[https://argoproj.github.io/cd][ArgoCD]] via the operator, so that all remaining steps can be performed in a GitOps manner.
 
 
-*** Login to the cluster
+*** 1.1 Login to the cluster
 
 Before we can run any of the following commands, we need to ensure we are logged in. Run the following to do so, updating the placeholder values:
 
@@ -25,7 +25,7 @@ oc login --token=<token> \
 #+end_src
 
 
-*** Install openshift gitops operator
+*** 1.2  Install openshift gitops operator
 
 We can programatically install the openshift gitops operator on the cluster in a declaritive way by creating a ~Subscription~ kubernetes custom resource to subscribe a given namespace to the Operator.
 
@@ -50,9 +50,11 @@ EOF
 #+end_src
 
 
-*** Update openshift gitops instance
+*** 1.3 Update openshift gitops instance rbac
 
 Once the operator is installed we can apply our ~ArgoCD~ custom resource definition. This will be picked up by the operator and an updated argocd instance will be deployed based on the specification we provided.
+
+The updates below are primarily to rbac, so that we can login via OpenShift SSO and still see applications targeting our local cluster.
 
 #+begin_src bash :results silent
 cat << EOF | oc apply --filename -
@@ -83,16 +85,16 @@ spec:
 EOF
 #+end_src
 
-Once the argocd instance has started we can access the web interface via the ~Route~ automatically created by the Operator.
+Once the argocd instance has started we can access the web interface via the ~Route~ automatically created by the Operator and click *"Login with OpenShift"*.
 
 #+begin_src bash :results silent
 echo "https://$(oc --namespace openshift-gitops get route openshift-gitops-server --output jsonpath='{.spec.host}')"
 #+end_src
 
 
-*** Create components with gitops
+** Step 2 - Create gitops applicationset
 
-From here, with openshift gitops running in our cluster, all we need to do is apply the argocd ~ApplicationSet~ custom resource shown below, which points to a git repository containing our remaining manifests.
+From here, with openshift gitops running in our cluster, all we need to do is apply the argocd ~ApplicationSet~ custom resource shown below, which points to our git repository containing our remaining manifests.
 
 This ~ApplicationSet~ resource will be picked up by ArgoCD and periodically synchronised to our cluster to create an ~Application~ for each of our required components.
 
@@ -130,4 +132,15 @@ spec:
         syncOptions:
           - CreateNamespace=true
 EOF
+#+end_src
+
+
+** Step 3 - Open our juypter notebook route
+
+Once our gitops ~Applications~ have completed syncing (this may take 5 minutes) we can run snippet below to retrieve our juypter notebook ~Route~ and open this in our browser of choice.
+
+Note the addition of the ~/notebook/rhods-notebooks/jupyter-nb-admin/lab~ trailing url fragment.
+
+#+begin_src bash :results silent
+echo "https://$(oc get route --namespace rhods-notebooks jupyter-nb-admin --output jsonpath={.spec.host})/notebook/rhods-notebooks/jupyter-nb-admin/lab"
 #+end_src

--- a/gitops-notebook/persistentvolumeclaim.yaml
+++ b/gitops-notebook/persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jupyterhub-nb-admin-pvc
+  namespace: rhods-notebooks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 20Gi


### PR DESCRIPTION
Add missing `persistentvolumeclaim` for the notebook to start without user interaction.

Also updated the walkthrough docs for a clear step by step process.