### PR TITLE
Add applicationset to argo spec for 4.14+ support

### DIFF
--- a/README.org
+++ b/README.org
@@ -68,6 +68,7 @@ spec:
   rbac:
     defaultPolicy: role:admin
     scopes: '[groups]'
+  applicationSet: {}
   resourceExclusions: |
     - kinds:
         - TaskRun


### PR DESCRIPTION
Refer: https://cloud.redhat.com/blog/an-introduction-to-applicationsets-in-openshift-gitops#:~:text=Under%20the%20YAML%20tab%2C%20ensure%20that%C2%A0